### PR TITLE
Fix  example `1-07-nodejs-naive-async-fileio`

### DIFF
--- a/chapter-1/1-07-nodejs-naive-async-fileio.html
+++ b/chapter-1/1-07-nodejs-naive-async-fileio.html
@@ -19,7 +19,9 @@ var fs = require('fs');
 var timestamp = new Date().toString();
 var contents;
 
-fs.writeFile('date.txt', timestamp);
+fs.writeFile('date.txt', timestamp, function (err) {
+	if (err) throw err;
+});
 
 fs.readFile('date.txt', function (err, data) {
 	if (err) throw err;

--- a/chapter-1/1-07-nodejs-naive-async-fileio.js
+++ b/chapter-1/1-07-nodejs-naive-async-fileio.js
@@ -4,7 +4,9 @@ var fs = require('fs');
 var timestamp = new Date().toString();
 var contents;
 
-fs.writeFile('date.txt', timestamp);
+fs.writeFile('date.txt', timestamp, function (err) {
+	if (err) throw err;
+});
 
 fs.readFile('date.txt', function (err, data) {
 	if (err) throw err;


### PR DESCRIPTION
# what/why

Example `1-07-nodejs-naive-async-fileio` seems to have a little problem: [`fs.writeFile()` requires a callback function as the last argument](https://nodejs.org/dist/latest-v6.x/docs/api/fs.html#fs_fs_writefile_file_data_options_callback) but it was not provided. This PR fixes it

# testing

## before

```
$ node 1-07-nodejs-naive-async-fileio.js 
node:internal/validators:440
    throw new ERR_INVALID_ARG_TYPE(name, 'Function', value);
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "cb" argument must be of type function. Received undefined
    at maybeCallback (node:fs:178:3)
    at Object.writeFile (node:fs:2286:14)
    at Object.<anonymous> (/Users/sryabkov/Projects/promises-book-examples/chapter-1/1-07-nodejs-naive-async-fileio.js:7:4)
    at Module._compile (node:internal/modules/cjs/loader:1241:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1295:10)
    at Module.load (node:internal/modules/cjs/loader:1091:32)
    at Module._load (node:internal/modules/cjs/loader:938:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:83:12)
    at node:internal/main/run_main_module:23:47 {
  code: 'ERR_INVALID_ARG_TYPE'
}

Node.js v20.6.0
```

## after

```
$ node 1-07-nodejs-naive-async-fileio.js 
Comparing the contents
Assertion failed
```